### PR TITLE
Objects list performance optimization for a flat structures in S3

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2301,8 +2301,8 @@ If empty it will default to the environment variable "AWS_PROFILE" or
 			Advanced:  true,
 			Sensitive: true,
 		}, {
-			Name:      "key_prefix",
-			Help:      "Key Prefix",
+			Name:      "list_key_prefix",
+			Help:      "List Key Prefix",
 			Advanced:  true,
 			Sensitive: true,
 		}, {
@@ -2882,7 +2882,7 @@ type Options struct {
 	LeavePartsOnError     bool                 `config:"leave_parts_on_error"`
 	ListChunk             int32                `config:"list_chunk"`
 	ListVersion           int                  `config:"list_version"`
-	KeyPrefix             string               `config:"key_prefix"`
+	ListKeyPrefix         string               `config:"list_key_prefix"`
 	ListURLEncode         fs.Tristate          `config:"list_url_encode"`
 	NoCheckBucket         bool                 `config:"no_check_bucket"`
 	NoHead                bool                 `config:"no_head"`
@@ -4220,7 +4220,7 @@ func (f *Fs) list(ctx context.Context, opt listOpt, fn listFn) error {
 	// So we enable only on providers we know supports it properly, all others can retry when a
 	// XML Syntax error is detected.
 	urlEncodeListings := f.opt.ListURLEncode.Value
-	prefix := opt.directory + f.opt.KeyPrefix
+	prefix := opt.directory + f.opt.ListKeyPrefix
 	req := s3.ListObjectsV2Input{
 		Bucket:    &opt.bucket,
 		Delimiter: &delimiter,

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2301,6 +2301,11 @@ If empty it will default to the environment variable "AWS_PROFILE" or
 			Advanced:  true,
 			Sensitive: true,
 		}, {
+			Name:      "key_prefix",
+			Help:      "Key Prefix",
+			Advanced:  true,
+			Sensitive: true,
+		}, {
 			Name: "upload_concurrency",
 			Help: `Concurrency for multipart uploads and copies.
 
@@ -2877,6 +2882,7 @@ type Options struct {
 	LeavePartsOnError     bool                 `config:"leave_parts_on_error"`
 	ListChunk             int32                `config:"list_chunk"`
 	ListVersion           int                  `config:"list_version"`
+	KeyPrefix             string               `config:"key_prefix"`
 	ListURLEncode         fs.Tristate          `config:"list_url_encode"`
 	NoCheckBucket         bool                 `config:"no_check_bucket"`
 	NoHead                bool                 `config:"no_head"`
@@ -4214,10 +4220,11 @@ func (f *Fs) list(ctx context.Context, opt listOpt, fn listFn) error {
 	// So we enable only on providers we know supports it properly, all others can retry when a
 	// XML Syntax error is detected.
 	urlEncodeListings := f.opt.ListURLEncode.Value
+	prefix := opt.directory + f.opt.KeyPrefix
 	req := s3.ListObjectsV2Input{
 		Bucket:    &opt.bucket,
 		Delimiter: &delimiter,
-		Prefix:    &opt.directory,
+		Prefix:    &prefix,
 		MaxKeys:   &f.opt.ListChunk,
 	}
 	if opt.restoreStatus {


### PR DESCRIPTION
#### What is the purpose of this change?

**Motivation**

Imagine you have a bucket in s3 with millions keys under the same prefix:

```plain
source-bucket/a/b/c/2020-01-01-10-00-00.log
source-bucket/a/b/c/2020-01-01-10-00-01.log
source-bucket/a/b/c/2020-01-01-10-00-02.log
... 
source-bucket/a/b/c/2022-12-31-10-00-00.log
...
source-bucket/a/b/c/2024-12-31-10-00-00.log
```

You want to copy all the objects for Dec 2022. You need to filter keys by prefix "2022-12-".

Rclone doesn't support a path as a prefix for keys:

```
rclone copy my-s3-source-remote:source-bucket/a/b/c/2022-12- my-destination-remote:destination-bucket/d/e/f
```

We can use [files matching pattern](https://rclone.org/filtering/#include-include-files-matching-pattern) as a possible solution:

```
rclone copy my-s3-remote:bucket/prefix my-destination-remote:destination-bucket/d/e/f --include "2022-12-*"
```

Rclone sends [ListObjectsV2](https://github.com/rclone/rclone/blob/v1.69.0/backend/s3/s3.go#L4180) with `a/b/c` as a prefix and **list all millions of keys under the prefix**. 

Optimized way is to send ListObjectsV2 request with a `prefix` equals to `a/b/c/2022-12-`. **S3 returns only keys starting with `a/b/c/2022-12-` bypassing unnecessary keys**. 

[--fast-list](https://rclone.org/docs/#fast-list) flag doesn't  help with flat structure. 

**Proposal**

Add a new flag `--s3-list-key-prefix` that modifies the ListObjectsV2 (and ListObjects) request to include a server-side filter for keys. This significantly improve performance for a flat structures.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/s3-listobjects-v2-performance-optimization-for-a-flat-structures/49860

#### Checklist

TBD

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
